### PR TITLE
Add condition to check for null

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ export default class SearchableDropDown extends Component{
   }
 
   searchedItems= (searchedText) => {
-      var ac = this.props.items.filter(function(item) {
+      var ac = this.props.items && this.props.items.filter(function(item) {
         return item.name.toLowerCase().indexOf(searchedText.toLowerCase()) > -1;
       });
       let item = {


### PR DESCRIPTION
When there are no items to search, an error is obtained saying 'Cannot read .filter() of null'
Added a  condition to check the same.