### PR TITLE
Accept 0 as defaultIndex

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ export default class SearchableDropDown extends Component {
   componentDidMount = () => {
     const listItems = this.props.items;
     const defaultIndex = this.props.defaultIndex;
-    if (defaultIndex && listItems.length > defaultIndex) {
+    if (!isNaN(defaultIndex) && listItems.length > defaultIndex) {
       this.setState({
         listItems,
         item: listItems[defaultIndex]


### PR DESCRIPTION
`0` will cast as `false` in a comparison statement.
This will check if the provided prop is a number, so it will accept 0 as defaultIndex.