### PR TITLE
Use custom onChangeText prop if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ export default class SearchableDropDown extends Component {
         }
       } else {
         if(kv.key === 'onTextChange' || kv.key === 'onChangeText') {
-          textInputProps['onChangeText'] = kv.val;
+          textInputProps['onChangeText'] = textInputProps['onChangeText'] || kv.val;
         }
       }
     });


### PR DESCRIPTION
There currently isn't support to override onChangeText prop. I have changed SearchableDropdown to use a custom onChangeText prop if it's present  😄 